### PR TITLE
Migrate from flake to deploy cue

### DIFF
--- a/artifacts.cue
+++ b/artifacts.cue
@@ -14,11 +14,11 @@ artifacts: {
 	"catalyst-dryrun": {
 		block0: {
 			url:      "s3::https://s3-eu-central-1.amazonaws.com/iohk-vit-artifacts/catalyst-dryrun/block0.bin"
-			checksum: "sha256:c498c81583bc50c75577464ab968c8da4dd85e2c5fb9e487e8aef09128881c7a"
+			checksum: "sha256:ca3aedd9c687712b466052bdfa71b2eddb9470d8513627c7d3c3b802fb88cc9a"
 		}
 		database: {
 			url:      "s3::https://s3-eu-central-1.amazonaws.com/iohk-vit-artifacts/catalyst-dryrun/database.sqlite3"
-			checksum: "sha256:769f9073ed3862102cb34dde516c3a1eb723da5c204023cb534a69353eecc0ab"
+			checksum: "sha256:07d6f8e5e02a62179e868f36aa4937e8e15c5603a684523bc7be16043083608c"
 		}
 	}
 	"catalyst-fund3": {

--- a/artifacts.cue
+++ b/artifacts.cue
@@ -14,11 +14,11 @@ artifacts: {
 	"catalyst-dryrun": {
 		block0: {
 			url:      "s3::https://s3-eu-central-1.amazonaws.com/iohk-vit-artifacts/catalyst-dryrun/block0.bin"
-			checksum: "sha256:ca3aedd9c687712b466052bdfa71b2eddb9470d8513627c7d3c3b802fb88cc9a"
+			checksum: "sha256:429e0264a5421b2221ad46c9085d5c6280b28328c9e124a6e5b04ee0a0ce76d3"
 		}
 		database: {
 			url:      "s3::https://s3-eu-central-1.amazonaws.com/iohk-vit-artifacts/catalyst-dryrun/database.sqlite3"
-			checksum: "sha256:07d6f8e5e02a62179e868f36aa4937e8e15c5603a684523bc7be16043083608c"
+			checksum: "sha256:ead6246097825f62e0b68739842591fe63c8b6c23707b5ee0c995e58cce7f062"
 		}
 	}
 	"catalyst-fund3": {

--- a/deploy.cue
+++ b/deploy.cue
@@ -41,8 +41,8 @@ Namespace: [Name=_]: {
 		#version:    string | *"2.0"
 
 		#flakes: {
-			#jormungandr:      string | *"github:input-output-hk/vit-ops?rev=c9251b4f3f0b34a22e3968bf28d5a049da120f8f#jormungandr-entrypoint"
-			#servicingStation: string | *"github:input-output-hk/vit-servicing-station/160f09c7a26fe31628b7573e8c326e3d90f1ab47#vit-servicing-station-server"
+			#jormungandr:      string | *"github:input-output-hk/jormungandr/edfe2c2a73de1d6548eaecbfb19b7c32aadbf178#jormungandr-entrypoint"
+			#servicingStation: string | *"github:input-output-hk/vit-servicing-station/70c54048d18835cdd34aedcbd3a9365c38eb7304#vit-servicing-station-server"
 		}
 
 		#rateLimit: {
@@ -60,10 +60,6 @@ Namespace: [Name=_]: {
 	"catalyst-dryrun": {
 		vars: {
 			#domain: "dryrun-servicing-station.\(fqdn)"
-			#flakes: {
-				#jormungandr:      "github:input-output-hk/vit-ops?rev=e81a05cc61beef935fb4bb8b9ec9407df44f2c68#jormungandr-entrypoint"
-				#servicingStation: "github:input-output-hk/vit-servicing-station/aab56840504e05920b8dd530c2ddc3dbdf9cde03#vit-servicing-station-server"
-			}
 		}
 		jobs: _defaultJobs
 	}
@@ -82,10 +78,6 @@ Namespace: [Name=_]: {
 	"catalyst-perf": {
 		vars: {
 			#domain: "perf-servicing-station.\(fqdn)"
-			#flakes: {
-				#jormungandr:      "github:input-output-hk/vit-ops?rev=e81a05cc61beef935fb4bb8b9ec9407df44f2c68#jormungandr-entrypoint"
-				#servicingStation: "github:input-output-hk/vit-servicing-station/aab56840504e05920b8dd530c2ddc3dbdf9cde03#vit-servicing-station-server"
-			}
 			#rateLimit: {
 				average: 100000
 				burst:   200000
@@ -98,10 +90,6 @@ Namespace: [Name=_]: {
 	"catalyst-signoff": {
 		vars: {
 			#domain: "signoff-servicing-station.\(fqdn)"
-			#flakes: {
-				#jormungandr:      "github:input-output-hk/vit-ops?rev=43525e606ca74a5b7cfa1c7f1f0ee3c24865ca30#jormungandr-entrypoint"
-				#servicingStation: "github:input-output-hk/vit-servicing-station/aab56840504e05920b8dd530c2ddc3dbdf9cde03#vit-servicing-station-server"
-			}
 		}
 		jobs: _defaultJobs
 	}

--- a/jobs/tasks/jormungandr.cue
+++ b/jobs/tasks/jormungandr.cue
@@ -88,23 +88,21 @@ import (
 		  "leadership": {
 		    "logs_capacity": 1024
 		  },
-		  "log": [
-		    {
-		      "format": "plain",
-		      "level": "debug",
-		      "output": "stdout"
-		    }
-		  ],
+		  "log": {
+		    "format": "plain",
+		    "level": "debug",
+		    "output": "stdout"
+		  },
 		  "mempool": {
 		    \(#mempool)
 		  },
 		  "p2p": {
 		    "allow_private_addresses": true,
-		    "topics_of_interest": {
+		    "layers": {
+		      "topics_of_interest": {
 		        "blocks": "high",
 		        "messages": "high"
-		    },
-		    "layers": {
+		      },
 		      "preferred_list": {
 		        "peers": [
 		          {{ range service "\(#namespace)-jormungandr-internal|any" }}
@@ -120,7 +118,7 @@ import (
 		        "view_max": 20
 		      }
 		    },
-		    "listen_address": "/ip4/0.0.0.0/tcp/{{ env "NOMAD_PORT_rpc" }}",
+		    "listen": "0.0.0.0:{{ env "NOMAD_PORT_rpc" }}",
 		    "max_bootstrap_attempts": 3,
 		    "max_client_connections": 192,
 		    "max_connections": 256,

--- a/overlay.nix
+++ b/overlay.nix
@@ -89,7 +89,6 @@ in {
       consul
       consul-template
       direnv
-      jormungandr
       jq
       nixfmt
       nomad

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -129,7 +129,7 @@ done
 sleep 10
 
 for job in leader-{0,1,2} follower-0 servicing-station; do
-  iogo plan "$NOMAD_NAMESPACE" "$job"
+  yes yes | iogo plan "$NOMAD_NAMESPACE" "$job" || true
 done
 
 


### PR DESCRIPTION
Change way how jormungandr version is provided. Right now it is taken directly from deploy.cue avoiding referencing vit-ops commit with updated flake.nix file