### PR TITLE
[VIT-1667] Adding additional routing-bench server to isolate perf env

### DIFF
--- a/clusters/vit/testnet/default.nix
+++ b/clusters/vit/testnet/default.nix
@@ -231,7 +231,7 @@ in {
         privateIP = "172.16.2.20";
         subnet = cluster.vpc.subnets.core-3;
         volumeSize = 30;
-        route53.domains = [ "bench.${cluster.domain}" ];
+        route53.domains = [ "perf-servicing-station.${cluster.domain}" ];
 
         modules = [ ./routing.nix ];
 

--- a/clusters/vit/testnet/default.nix
+++ b/clusters/vit/testnet/default.nix
@@ -226,6 +226,20 @@ in {
         };
       };
 
+      routing-bench = {
+        instanceType = "t3a.small";
+        privateIP = "172.16.2.20";
+        subnet = cluster.vpc.subnets.core-3;
+        volumeSize = 30;
+        route53.domains = [ "bench.${cluster.domain}" ];
+
+        modules = [ ./routing.nix ];
+
+        securityGroupRules = {
+          inherit (securityGroupRules) internet internal ssh http routing;
+        };
+      };
+
       storage-0 = {
         instanceType = "t3a.small";
         privateIP = "172.16.0.50";


### PR DESCRIPTION
[VIT-1667](https://jira.iohk.io/browse/VIT-1667)

Adding additional routing bench server. It would route traffic only for catalyst-perf env in response to requests sent to perf-servicing-station subdomain.