### PR TITLE
Adding second vit servicing station instance

### DIFF
--- a/jobs/servicing-station.cue
+++ b/jobs/servicing-station.cue
@@ -28,6 +28,8 @@ import (
 			port: "promtail": {}
 		}
 
+		count: 2
+
 		service: "\(namespace)-servicing-station": {
 			address_mode: "host"
 			port:         "web"


### PR DESCRIPTION
Increasing job count for vit-servicing stations. This is already scaled adn tested on all environments and this is just to sync the state.